### PR TITLE
switch to a common layout class, add layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ circup install keyboard_layout_win_fr
 
 `keyboard_layout_<platform>_<lang>` modules will contain the layout information for use with the `Keyboard` to type text.
 
+They require also installing the `keyboard_layout.py` file, containing the base class and methods that are used by the layout. This file should be part of adafruit_hid in the future and will be removed.
+
 ```py
 import usb_hid
 from adafruit_hid.keyboard import Keyboard
@@ -36,4 +38,4 @@ kbd.send(Keycode.COMMAND, Keycode.A)
 
 ### NOTE
 
-This is pretty much experimental for now, the layout and keycode files are stand-ins.
+A few layouts and keycodes are currently implemented, they are not thouroughly tested. The `keycode_mac_fr.py` file is more experimental.

--- a/build.py
+++ b/build.py
@@ -134,7 +134,11 @@ def make_bundle_files():
     shutil.copytree(MODULES_DIR, fmt(BUNDLE_LIB_DIR))
 
     # list of the modules
-    all_modules = [mod.replace(".py", "") for mod in os.listdir(MODULES_DIR)]
+    all_modules = [
+        mod.replace(".py", "")
+        for mod in os.listdir(MODULES_DIR)
+        if not mod.startswith(".")
+    ]
 
     json_data = {}
 
@@ -155,6 +159,11 @@ def make_bundle_files():
             "dependencies": [],  # "adafruit_hid"
             "external_dependencies": ["adafruit-circuitpython-hid"],
         }
+        # add the dependency to keyboard_layout
+        if module.startswith("keyboard_layout_"):
+            json_data[module]["dependencies"].append("keyboard_layout")
+            with open(target,"a") as fp:
+                fp.write("\r\nkeyboard_layout\r\n")
 
     # create the json file
     with open(BUNDLE_JSON, "w") as out_file:

--- a/libraries/keyboard_layout.py
+++ b/libraries/keyboard_layout.py
@@ -82,12 +82,15 @@ class KeyboardLayout:
             keycodes('é')
         """
         keycode = self._char_to_keycode(char)
-        if keycode & self.SHIFT_FLAG:
-            return (self.SHIFT_CODE, keycode & ~self.SHIFT_FLAG)
+        codes = []
         if char in self.NEED_ALTGR:
-            return (self.RIGHT_ALT_CODE, keycode)
+            codes.append(self.RIGHT_ALT_CODE)
+        if keycode & self.SHIFT_FLAG:
+            codes.extend((self.SHIFT_CODE, keycode & ~self.SHIFT_FLAG))
+        else:
+            codes.append(keycode)
 
-        return (keycode,)
+        return codes
 
     def _above128charval_to_keycode(self, char_val):
         """Return keycode for above 128 ascii codes.

--- a/libraries/keyboard_layout.py
+++ b/libraries/keyboard_layout.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2017 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_hid.keyboard_layout_us.KeyboardLayoutUS`
+=======================================================
+
+* Author(s): Dan Halbert, AngainorDev
+"""
+
+
+class KeyboardLayout:
+    """Map ASCII characters to appropriate keypresses on a standard US PC keyboard.
+
+    Non-ASCII characters and most control characters will raise an exception.
+    """
+
+    # We use the top bit of each byte (0x80) to indicate
+    # that the shift key should be pressed, and an extra 9th bit 0x100 for AltGr
+    SHIFT_FLAG = 0x80
+    ALTGR_FLAG = 0x100
+    ASCII_TO_KEYCODE = ()
+    NEED_ALTGR = ""
+    HIGHER_ASCII = {}
+    RIGHT_ALT_CODE = 0xE6
+    SHIFT_CODE = 0xE1
+
+    def __init__(self, keyboard):
+        """Specify the layout for the given keyboard.
+
+        :param keyboard: a Keyboard object. Write characters to this keyboard when requested.
+
+        Example::
+
+            kbd = Keyboard(usb_hid.devices)
+            layout = KeyboardLayoutUS(kbd)
+        """
+        self.keyboard = keyboard
+
+    def write(self, string):
+        """Type the string by pressing and releasing keys on my keyboard.
+
+        :param string: A string of ASCII characters.
+        :raises ValueError: if any of the characters are not ASCII or have no keycode
+            (such as some control characters).
+
+        Example::
+
+            # Write abc followed by Enter to the keyboard
+            layout.write('abc\\n')
+        """
+        for char in string:
+            keycode = self._char_to_keycode(char)
+            if char in self.NEED_ALTGR:
+                # Add altgr modifier
+                self.keyboard.press(self.RIGHT_ALT_CODE)
+            # If this is a shifted char, clear the SHIFT flag and press the SHIFT key.
+            if keycode & self.SHIFT_FLAG:
+                keycode &= ~self.SHIFT_FLAG
+                self.keyboard.press(self.SHIFT_CODE)
+            self.keyboard.press(keycode)
+            self.keyboard.release_all()
+
+    def keycodes(self, char):
+        """Return a tuple of keycodes needed to type the given character.
+
+        :param char: A single ASCII character in a string.
+        :type char: str of length one.
+        :returns: tuple of Keycode keycodes.
+        :raises ValueError: if ``char`` is not ASCII or there is no keycode for it.
+
+        Examples::
+
+            # Returns (Keycode.TAB,)
+            keycodes('\t')
+            # Returns (Keycode.A,)
+            keycodes('a')
+            # Returns (Keycode.SHIFT, Keycode.A)
+            keycodes('A')
+            # Raises ValueError because it's a accented e and is not ASCII
+            keycodes('é')
+        """
+        keycode = self._char_to_keycode(char)
+        if keycode & self.SHIFT_FLAG:
+            return (self.SHIFT_CODE, keycode & ~self.SHIFT_FLAG)
+        if char in self.NEED_ALTGR:
+            return (self.RIGHT_ALT_CODE, keycode)
+
+        return (keycode,)
+
+    def _above128charval_to_keycode(self, char_val):
+        """Return keycode for above 128 ascii codes.
+
+        Since the values are sparse, this may be more space efficient than bloating the table above
+        or adding a dict.
+
+        :param char_val: ascii char value
+        :return: keycode, with modifiers if needed
+        """
+        if char_val in self.HIGHER_ASCII:
+            return self.HIGHER_ASCII[char_val]
+        if ord(char_val) in self.HIGHER_ASCII:
+            return self.HIGHER_ASCII[char_val]
+
+        raise ValueError("Unsupported non-ASCII character \\x{}.".format(ord(char_val)))
+
+    def _char_to_keycode(self, char):
+        """Return the HID keycode for the given ASCII character, with the SHIFT_FLAG possibly set.
+
+        If the character requires pressing the Shift key, the SHIFT_FLAG bit is set.
+        You must clear this bit before passing the keycode in a USB report.
+        """
+        char_val = ord(char)
+        if char_val > 128:
+            return self._above128charval_to_keycode(char)
+        keycode = self.ASCII_TO_KEYCODE[char_val]
+        if keycode == 0:
+            raise ValueError("No keycode available for character.")
+        return keycode

--- a/libraries/keyboard_layout_mac_fr.py
+++ b/libraries/keyboard_layout_mac_fr.py
@@ -25,15 +25,14 @@
 * Author(s): Dan Halbert, Neradoc
 """
 
-#from .keycode import Keycode
-from adafruit_hid.keycode import Keycode
+from keyboard_layout import KeyboardLayout
 
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/Neradoc/Circuitpython_Keyboard_Layouts.git"
 
 
-class KeyboardLayoutMacFR:
+class KeyboardLayoutMacFR(KeyboardLayout):
     """Map ASCII characters to appropriate keypresses on a FR Mac keyboard.
     Non-ASCII characters and most control characters will raise an exception.
     """
@@ -51,216 +50,150 @@ class KeyboardLayoutMacFR:
     # if it's in a .mpy file, so it doesn't use up valuable RAM.
     #
     # \x00 entries have no keyboard key and so won't be sent.
-    NUL = b'\x00'
-    SHIFT = b'\x02'
-    ALTGR = b'\x40'
-    ALTSHIFT = b'\x42'
+    SHIFT_FLAG = 0x80
+    
     ASCII_TO_KEYCODE = (
-        NUL+b'\x00'     # NUL
-        +NUL+b'\x00'    # SOH
-        +NUL+b'\x00'    # STX
-        +NUL+b'\x00'    # ETX
-        +NUL+b'\x00'    # EOT
-        +NUL+b'\x00'    # ENQ
-        +NUL+b'\x00'    # ACK
-        +NUL+b'\x00'    # BEL \a
-        +NUL+b'\x2a'    # BS BACKSPACE \b (called DELETE in the usb.org document)
-        +NUL+b'\x2b'    # TAB \t
-        +NUL+b'\x28'    # LF \n (called Return or ENTER in the usb.org document)
-        +NUL+b'\x00'    # VT \v
-        +NUL+b'\x00'    # FF \f
-        +NUL+b'\x00'    # CR \r
-        +NUL+b'\x00'    # SO
-        +NUL+b'\x00'    # SI
-        +NUL+b'\x00'    # DLE
-        +NUL+b'\x00'    # DC1
-        +NUL+b'\x00'    # DC2
-        +NUL+b'\x00'    # DC3
-        +NUL+b'\x00'    # DC4
-        +NUL+b'\x00'    # NAK
-        +NUL+b'\x00'    # SYN
-        +NUL+b'\x00'    # ETB
-        +NUL+b'\x00'    # CAN
-        +NUL+b'\x00'    # EM
-        +NUL+b'\x00'    # SUB
-        +NUL+b'\x29'    # ESC
-        +NUL+b'\x00'    # FS
-        +NUL+b'\x00'    # GS
-        +NUL+b'\x00'    # RS
-        +NUL+b'\x00'    # US
+        b'\x00'     # NUL
+        b'\x00'    # SOH
+        b'\x00'    # STX
+        b'\x00'    # ETX
+        b'\x00'    # EOT
+        b'\x00'    # ENQ
+        b'\x00'    # ACK
+        b'\x00'    # BEL \a
+        b'\x2a'    # BS BACKSPACE \b (called DELETE in the usb.org document)
+        b'\x2b'    # TAB \t
+        b'\x28'    # LF \n (called Return or ENTER in the usb.org document)
+        b'\x00'    # VT \v
+        b'\x00'    # FF \f
+        b'\x00'    # CR \r
+        b'\x00'    # SO
+        b'\x00'    # SI
+        b'\x00'    # DLE
+        b'\x00'    # DC1
+        b'\x00'    # DC2
+        b'\x00'    # DC3
+        b'\x00'    # DC4
+        b'\x00'    # NAK
+        b'\x00'    # SYN
+        b'\x00'    # ETB
+        b'\x00'    # CAN
+        b'\x00'    # EM
+        b'\x00'    # SUB
+        b'\x29'    # ESC
+        b'\x00'    # FS
+        b'\x00'    # GS
+        b'\x00'    # RS
+        b'\x00'    # US
         
-        +NUL+b'\x2c'       #  ' '
-        +NUL+b'\x25'       # !
-        +NUL+b'\x20'       # "
-        +SHIFT+b'\x64'    # #
-        +NUL+b'\x30'       # $
-        +SHIFT+b'\x34'    # %
-        +NUL+b'\x1E'       # &
-        +NUL+b'\x21'       # '
-        +NUL+b'\x22'       # (
-        +NUL+b'\x2d'       # )
-        +SHIFT+b'\x30'    # *
-        +SHIFT+b'\x38'    # +
-        +NUL+b'\x10'       # ,
-        +NUL+b'\x2E'       # -
-        +SHIFT+b'\x36'    # .
-        +SHIFT+b'\x37'    # /
-        +SHIFT+b'\x27'    # 0
-        +SHIFT+b'\x1e'    # 1
-        +SHIFT+b'\x1f'    # 2
-        +SHIFT+b'\x20'    # 3
-        +SHIFT+b'\x21'    # 4
-        +SHIFT+b'\x22'    # 5
-        +SHIFT+b'\x23'    # 6
-        +SHIFT+b'\x24'    # 7
-        +SHIFT+b'\x25'    # 8
-        +SHIFT+b'\x26'    # 9
-        +NUL+b'\x37'       # :
-        +NUL+b'\x36'       # ;
-        +NUL+b'\x35'       # <
-        +NUL+b'\x38'       # =
-        +SHIFT+b'\x35'    # >
-        +SHIFT+b'\x10'    # ?
-        +NUL+b'\x64'       # @
-        +SHIFT+b'\x14'    # A
-        +SHIFT+b'\x05'    # B
-        +SHIFT+b'\x06'    # C
-        +SHIFT+b'\x07'    # D
-        +SHIFT+b'\x08'    # E
-        +SHIFT+b'\x09'    # F
-        +SHIFT+b'\x0a'    # G
-        +SHIFT+b'\x0b'    # H
-        +SHIFT+b'\x0c'    # I
-        +SHIFT+b'\x0d'    # J
-        +SHIFT+b'\x0e'    # K
-        +SHIFT+b'\x0f'    # L
-        +SHIFT+b'\x33'    # M
-        +SHIFT+b'\x11'    # N
-        +SHIFT+b'\x12'    # O
-        +SHIFT+b'\x13'    # P
-        +SHIFT+b'\x04'    # Q
-        +SHIFT+b'\x15'    # R
-        +SHIFT+b'\x16'    # S
-        +SHIFT+b'\x17'    # T
-        +SHIFT+b'\x18'    # U
-        +SHIFT+b'\x19'    # V
-        +SHIFT+b'\x1d'    # W
-        +SHIFT+b'\x1b'    # X
-        +SHIFT+b'\x1c'    # Y
-        +SHIFT+b'\x1a'    # Z
-        +ALTSHIFT+b'\x22'    # [
-        +ALTSHIFT+b'\x37'       # bslash
-        +ALTSHIFT+b'\x2d'    # ]
-        +NUL+b'\x2F'       # ^
-        +SHIFT+b'\x2E'       # _
-        +NUL+b'\x31'    # `
-        +NUL+b'\x14'       # a
-        +NUL+b'\x05'       # b
-        +NUL+b'\x06'       # c
-        +NUL+b'\x07'       # d
-        +NUL+b'\x08'       # e
-        +NUL+b'\x09'       # f
-        +NUL+b'\x0a'       # g
-        +NUL+b'\x0b'       # h
-        +NUL+b'\x0c'       # i
-        +NUL+b'\x0d'       # j
-        +NUL+b'\x0e'       # k
-        +NUL+b'\x0f'       # l
-        +NUL+b'\x33'       # m
-        +NUL+b'\x11'       # n
-        +NUL+b'\x12'       # o
-        +NUL+b'\x13'       # p
-        +NUL+b'\x04'       # q
-        +NUL+b'\x15'       # r
-        +NUL+b'\x16'       # s
-        +NUL+b'\x17'       # t
-        +NUL+b'\x18'       # u
-        +NUL+b'\x19'       # v
-        +NUL+b'\x1d'       # w
-        +NUL+b'\x1b'       # x
-        +NUL+b'\x1c'       # y
-        +NUL+b'\x1a'       # z
-        +ALTGR+b'\x22'    # {
-        +ALTSHIFT+b'\x0f'    # |
-        +ALTGR+b'\x2d'    # }
-        +ALTGR+b'\x11'    # ~ TODO
-        +NUL+b'\x00'       # DEL
+        b'\x2c'       #  ' '
+        b'\x25'       # !
+        b'\x20'       # "
+        b'\xe4'    # #
+        b'\x30'       # $
+        b'\xb4'    # %
+        b'\x1E'       # &
+        b'\x21'       # '
+        b'\x22'       # (
+        b'\x2d'       # )
+        b'\xb0'    # *
+        b'\xb8'    # +
+        b'\x10'       # ,
+        b'\x2E'       # -
+        b'\xb6'    # .
+        b'\xb7'    # /
+        b'\xa7'    # 0
+        b'\x9e'    # 1
+        b'\x9f'    # 2
+        b'\xa0'    # 3
+        b'\xa1'    # 4
+        b'\xa2'    # 5
+        b'\xa3'    # 6
+        b'\xa4'    # 7
+        b'\xa5'    # 8
+        b'\xa6'    # 9
+        b'\x37'       # :
+        b'\x36'       # ;
+        b'\x35'       # <
+        b'\x38'       # =
+        b'\xb5'    # >
+        b'\x90'    # ?
+        b'\x64'       # @
+        b'\x94'    # A
+        b'\x85'    # B
+        b'\x86'    # C
+        b'\x87'    # D
+        b'\x88'    # E
+        b'\x89'    # F
+        b'\x8a'    # G
+        b'\x8b'    # H
+        b'\x8c'    # I
+        b'\x8d'    # J
+        b'\x8e'    # K
+        b'\x8f'    # L
+        b'\xb3'    # M
+        b'\x91'    # N
+        b'\x92'    # O
+        b'\x93'    # P
+        b'\x84'    # Q
+        b'\x95'    # R
+        b'\x96'    # S
+        b'\x97'    # T
+        b'\x98'    # U
+        b'\x99'    # V
+        b'\x9d'    # W
+        b'\x9b'    # X
+        b'\x9c'    # Y
+        b'\x9a'    # Z
+        b'\xa2'    # [
+        b'\xb7'       # bslash
+        b'\xad'    # ]
+        b'\x2F'       # ^
+        b'\xaE'       # _
+        b'\x31'    # `
+        b'\x14'       # a
+        b'\x05'       # b
+        b'\x06'       # c
+        b'\x07'       # d
+        b'\x08'       # e
+        b'\x09'       # f
+        b'\x0a'       # g
+        b'\x0b'       # h
+        b'\x0c'       # i
+        b'\x0d'       # j
+        b'\x0e'       # k
+        b'\x0f'       # l
+        b'\x33'       # m
+        b'\x11'       # n
+        b'\x12'       # o
+        b'\x13'       # p
+        b'\x04'       # q
+        b'\x15'       # r
+        b'\x16'       # s
+        b'\x17'       # t
+        b'\x18'       # u
+        b'\x19'       # v
+        b'\x1d'       # w
+        b'\x1b'       # x
+        b'\x1c'       # y
+        b'\x1a'       # z
+        b'\x22'    # {
+        b'\x1f'    # |
+        b'\x2d'    # }
+        b'\x11'    # ~ TODO
+        b'\x00'       # DEL
     )
 
-    def __init__(self, keyboard):
-        """Specify the layout for the given keyboard.
+    NEED_ALTGR = "[]\\{}|~€"
+    HIGHER_ASCII = {
+        "à": 0x27,  # à
+        "ç": 0x26,  # ç
+        "è": 0x24,  # è
+        "é": 0x1F,  # é
+        "ù": 0x34,  # ù
+        "€": 0x30,  # € - altgr will be added thanks to NEED_ALTGR
+        "°": 0xAD,  # °
+        "§": 0x23,  # §
+        #  TODO: add missing ÀÈÉÙ
+    }
 
-        :param keyboard: a Keyboard object. Write characters to this keyboard when requested.
-
-        Example::
-
-            kbd = Keyboard()
-            layout = KeyboardLayoutFR(kbd)
-        """
-
-        self.keyboard = keyboard
-
-    def write(self, string):
-        """Type the string by pressing and releasing keys on my keyboard.
-
-        :param string: A string of ASCII characters.
-        :raises ValueError: if any of the characters are not ASCII or have no keycode
-            (such as some control characters).
-
-        Example::
-
-            # Write abc followed by Enter to the keyboard
-            layout.write('abc\\n')
-        """
-        for char in string:
-            (modifier,keycode) = self._char_to_keycode(char)
-            # If this is a shifted char, clear the SHIFT flag and press the SHIFT key.
-            if modifier & self.SHIFT[0]:
-                self.keyboard.press(Keycode.SHIFT)
-            if modifier & self.ALTGR[0]:
-                self.keyboard.press(Keycode.GUI)
-            self.keyboard.press(keycode)
-            self.keyboard.release_all()
-
-    def keycodes(self, char):
-        """Return a tuple of keycodes needed to type the given character.
-
-        :param char: A single ASCII character in a string.
-        :type char: str of length one.
-        :returns: tuple of Keycode keycodes.
-        :raises ValueError: if ``char`` is not ASCII or there is no keycode for it.
-
-        Examples::
-
-            # Returns (Keycode.TAB,)
-            keycodes('\t')
-            # Returns (Keycode.A,)
-            keycode('a')
-            # Returns (Keycode.SHIFT, Keycode.A)
-            keycode('A')
-            # Raises ValueError because it's a accented e and is not ASCII
-            keycode('é')
-        """
-        out = []
-        (modifier,keycode) = self._char_to_keycode(char)
-        if modifier & self.SHIFT:
-            out += [Keycode.SHIFT]
-        if modifier & self.ALTGR:
-            out += [Keycode.GUI]
-        out += [keycode]
-        return out
-
-    def _char_to_keycode(self, char):
-        """Return the HID keycode for the given ASCII character, with the SHIFT_FLAG possibly set.
-
-        If the character requires pressing the Shift key, the SHIFT_FLAG bit is set.
-        You must clear this bit before passing the keycode in a USB report.
-        """
-        char_val = ord(char)*2
-        if char_val+1 >= len(self.ASCII_TO_KEYCODE):
-            raise ValueError("Unknown character.")
-        modifier = self.ASCII_TO_KEYCODE[char_val]
-        keycode = self.ASCII_TO_KEYCODE[char_val+1]
-        if keycode == 0:
-            raise ValueError("No keycode available for character.")
-        return (modifier,keycode)

--- a/libraries/keyboard_layout_us_dvo.py
+++ b/libraries/keyboard_layout_us_dvo.py
@@ -1,0 +1,156 @@
+from keyboard_layout import KeyboardLayout
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/Neradoc/Circuitpython_Keyboard_Layouts.git"
+
+
+# Verbatim copy from keyboard_layout_us, only rewritten the ASCII_TO_KEYCODE table to match the Dvorak keycodes.
+class KeyboardLayoutUSDVO(KeyboardLayout):
+    """Map ASCII characters to appropriate keypresses on a standard US PC keyboard.
+    Non-ASCII characters and most control characters will raise an exception.
+    """
+
+    # The ASCII_TO_KEYCODE bytes object is used as a table to maps ASCII 0-127
+    # to the corresponding # keycode on a US 104-key keyboard.
+    # The user should not normally need to use this table,
+    # but it is not marked as private.
+    #
+    # Because the table only goes to 127, we use the top bit of each byte (ox80) to indicate
+    # that the shift key should be pressed. So any values 0x{8,9,a,b}* are shifted characters.
+    #
+    # The Python compiler will concatenate all these bytes literals into a single bytes object.
+    # Micropython/CircuitPython will store the resulting bytes constant in flash memory
+    # if it's in a .mpy file, so it doesn't use up valuable RAM.
+    #
+    # \x00 entries have no keyboard key and so won't be sent.
+    SHIFT_FLAG = 0x80
+    ASCII_TO_KEYCODE = (
+        b"\x00"  # NUL
+        b"\x00"  # SOH
+        b"\x00"  # STX
+        b"\x00"  # ETX
+        b"\x00"  # EOT
+        b"\x00"  # ENQ
+        b"\x00"  # ACK
+        b"\x00"  # BEL \a
+        b"\x2a"  # BS BACKSPACE \b (called DELETE in the usb.org document)
+        b"\x2b"  # TAB \t
+        b"\x28"  # LF \n (called Return or ENTER in the usb.org document)
+        b"\x00"  # VT \v
+        b"\x00"  # FF \f
+        b"\x00"  # CR \r
+        b"\x00"  # SO
+        b"\x00"  # SI
+        b"\x00"  # DLE
+        b"\x00"  # DC1
+        b"\x00"  # DC2
+        b"\x00"  # DC3
+        b"\x00"  # DC4
+        b"\x00"  # NAK
+        b"\x00"  # SYN
+        b"\x00"  # ETB
+        b"\x00"  # CAN
+        b"\x00"  # EM
+        b"\x00"  # SUB
+        b"\x29"  # ESC
+        b"\x00"  # FS
+        b"\x00"  # GS
+        b"\x00"  # RS
+        b"\x00"  # US
+        b"\x2c"  # SPACE
+        b"\x9e"  # !
+        b"\x94"  # "
+        b"\xa0"  # #
+        b"\xa1"  # $
+        b"\xa2"  # %
+        b"\xa4"  # &
+        b"\x14"  # '
+        b"\xa6"  # (
+        b"\xa7"  # )
+        b"\xa5"  # *
+        b"\xb0"  # +
+        b"\x1a"  # ,
+        b"\x34"  # -
+        b"\x08"  # .
+        b"\x2f"  # /
+        b"\x27"  # 0
+        b"\x1e"  # 1
+        b"\x1f"  # 2
+        b"\x20"  # 3
+        b"\x21"  # 4
+        b"\x22"  # 5
+        b"\x23"  # 6
+        b"\x24"  # 7
+        b"\x25"  # 8
+        b"\x26"  # 9
+        b"\x9d"  # :
+        b"\x1d"  # ;
+        b"\x9a"  # <
+        b"\x30"  # =
+        b"\x88"  # >
+        b"\xaf"  # ?
+        b"\x9f"  # @
+        b"\x84"  # A
+        b"\x91"  # B
+        b"\x8c"  # C
+        b"\x8b"  # D
+        b"\x87"  # E
+        b"\x9c"  # F
+        b"\x98"  # G
+        b"\x8d"  # H
+        b"\x8a"  # I
+        b"\x86"  # J
+        b"\x99"  # K
+        b"\x93"  # L
+        b"\x90"  # M
+        b"\x8f"  # N
+        b"\x96"  # O
+        b"\x95"  # P
+        b"\x92"  # R
+        b"\x9b"  # Q
+        b"\xb3"  # S
+        b"\x8e"  # T
+        b"\x89"  # U
+        b"\xb7"  # V
+        b"\xb6"  # W
+        b"\x85"  # X
+        b"\x97"  # Y
+        b"\xb8"  # Z
+        b"\x2d"  # [
+        b"\x31"  # \ backslash
+        b"\x2e"  # ]
+        b"\xa3"  # ^
+        b"\xb4"  # _
+        b"\x35"  # `
+        b"\x04"  # a
+        b"\x11"  # b
+        b"\x0c"  # c
+        b"\x0b"  # d
+        b"\x07"  # e
+        b"\x1c"  # f
+        b"\x18"  # g
+        b"\x0d"  # h
+        b"\x0a"  # i
+        b"\x06"  # j
+        b"\x19"  # k
+        b"\x13"  # l
+        b"\x10"  # m
+        b"\x0f"  # n
+        b"\x16"  # o
+        b"\x15"  # p
+        b"\x1b"  # q
+        b"\x12"  # r
+        b"\x33"  # s
+        b"\x0e"  # t
+        b"\x09"  # u
+        b"\x37"  # v
+        b"\x36"  # w
+        b"\x05"  # x
+        b"\x17"  # y
+        b"\x38"  # z
+        b"\xad"  # {
+        b"\xb1"  # |
+        b"\xae"  # }
+        b"\xb5"  # ~
+        b"\x4c"  # DEL DELETE (called Forward Delete in usb.org document)
+    )

--- a/libraries/keyboard_layout_win_de_de.py
+++ b/libraries/keyboard_layout_win_de_de.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: 2020, Bitboy85
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_hid.de_de`
+=======================================================
+# The index of the array represents the 8-bit ascii code.
+# The tupple of each index represents the keys needed to be pressed for this ascii character
+# For example: on german layouts @ is written by ALT_R(AltGr) + q
+# keycodes of 0x00 are ignored, those represent non-printable chars or characters
+# which cannot be entered by key combination
+
+* Author(s): Bitboy85
+"""
+#pylint: disable=duplicate-code
+
+
+from keyboard_layout import KeyboardLayout
+
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/Neradoc/Circuitpython_Keyboard_Layouts.git"
+
+
+class KeyboardLayoutWinDeDe(KeyboardLayout):
+    ASCII_TO_KEYCODE = (
+        b"\x00"             # NUL
+        b"\x00"             # SOH
+        b"\x00"             # STX
+        b"\x00"             # ETX
+        b"\x00"             # EOT
+        b"\x00"             # ENQ
+        b"\x00"             # ACK
+        b"\x00"             # BEL
+        b"\x2a"             # BS	Backspace
+        b"\x2b"             # TAB	Tab
+        b"\x28"             # LF	Enter
+        b"\x00"             # VT
+        b"\x00"             # FF
+        b"\x00"             # CR
+        b"\x00"             # SO
+        b"\x00"             # SI
+        b"\x00"             # DEL
+        b"\x00"             # DC1
+        b"\x00"             # DC2
+        b"\x00"             # DC3
+        b"\x00"             # DC4
+        b"\x00"             # NAK
+        b"\x00"             # SYN
+        b"\x00"             # ETB
+        b"\x00"             # CAN
+        b"\x00"             # EM
+        b"\x00"             # SUB
+        b"\x00"             # ESC
+        b"\x00"             # FS
+        b"\x00"             # GS
+        b"\x00"             # RS
+        b"\x00"             # US
+
+        b"\x2c"		                    # SPACE
+        b"\x9e"	    # !
+        b"\x9f"	    # "
+        b"\x31"                         # #
+        b"\xa1"     # $
+        b"\xa2"     # %
+        b"\xa3"     # &
+        b"\xb1"     # '
+        b"\xa5"     # (
+        b"\xa6"     # )
+        b"\xb0"     # *
+        b"\x30"                         # +
+        b"\x36"                         # ,
+        b"\x38"                         # -
+        b"\x37"                         # .
+        b"\xa4"     # /
+        b"\x27"                         # 0
+        b"\x1e"                         # 1
+        b"\x1f"                         # 2
+        b"\x20"                         # 3
+        b"\x21"                         # 4
+        b"\x22"                         # 5
+        b"\x23"                         # 6
+        b"\x24"                         # 7
+        b"\x25"                         # 8
+        b"\x26"                         # 9
+        b"\xb7"     # :
+        b"\xb6"     # ;
+        b"\x64"                         # <
+        b"\xa7"     # =
+        b"\xe4"     # >
+        b"\xad"     # ?
+        b"\x14",      # @
+        b"\x84"     # A
+        b"\x85"     # B
+        b"\x86"     # C
+        b"\x87"     # D
+        b"\x88"     # E
+        b"\x89"     # F
+        b"\x8a"     # G
+        b"\x8b"     # H
+        b"\x8c"     # I
+        b"\x8d"     # J
+        b"\x8e"     # K
+        b"\x8f"     # L
+        b"\x90"     # M
+        b"\x91"     # N
+        b"\x92"     # O
+        b"\x93"     # P
+        b"\x94"     # Q
+        b"\x95"     # R
+        b"\x96"     # S
+        b"\x97"     # T
+        b"\x98"     # U
+        b"\x99"     # V
+        b"\x9a"     # W
+        b"\x9b"     # X
+        b"\x9d"     # Y
+        b"\x9c"     # Z
+        b"\x25",      # [
+        b"\x2d",      # bslash \
+        b"\x26",      # ]
+        b"\x35"                         # ^
+        b"\xb8"     # _
+        b"\xae"     # `
+        b"\x04"                         # a
+        b"\x05"                         # b
+        b"\x06"                         # c
+        b"\x07"                         # d
+        b"\x08"                         # e
+        b"\x09"                         # f
+        b"\x0a"                         # g
+        b"\x0b"                         # h
+        b"\x0c"                         # i
+        b"\x0d"                         # j
+        b"\x0e"                         # k
+        b"\x0f"                         # l
+        b"\x10"                         # m
+        b"\x11"                         # n
+        b"\x12"                         # o
+        b"\x13"                         # p
+        b"\x14"                         # q
+        b"\x15"                         # r
+        b"\x16"                         # s
+        b"\x17"                         # t
+        b"\x18"                         # u
+        b"\x19"                         # v
+        b"\x1a"                         # w
+        b"\x1b"                         # x
+        b"\x1d"                         # y
+        b"\x1c"                         # z
+        b"\x24",      # {
+        b"\x64",      # |
+        b"\x27",      # }
+        b"\x30",      # ~
+        b"\x4c"				            # DEL
+        b"\x00" # [NOT printable] in some docs shown as € symbol, but not so in python
+        b"\x00" # [not printable]
+        b"\x00" # ‚
+        b"\x00" # ƒ
+        b"\x00" # „
+        b"\x00" # …
+        b"\x00" # †
+        b"\x00" # ‡
+        b"\x00" # ˆ
+        b"\x00" # ‰
+        b"\x00" # Š
+        b"\x00" # ‹
+        b"\x00" # Œ
+        b"\x00" # 
+        b"\x00" # Ž
+        b"\x00" # [not printable]
+        b"\x00" # [not printable]
+        b"\x00" # ‘
+        b"\x00" # ’
+        b"\x00" # “
+        b"\x00" # ”
+        b"\x00" # •
+        b"\x00" # –
+        b"\x00" # —
+        b"\x00" # ˜
+        b"\x00" # ™
+        b"\x00" # š
+        b"\x00" # ›
+        b"\x00" # œ
+        b"\x00" # [not printable]
+        b"\x00" # ž
+        b"\x00" # Ÿ
+        b"\x00" # [not printable]
+        b"\x00" # ¡
+        b"\x00" # ¢
+        b"\x00" # £
+        b"\x00" # ¤
+        b"\x00" # ¥
+        b"\x00" # ¦
+        b"\xa0"     # §
+        b"\x00" # ¨
+        b"\x00" # ©
+        b"\x00" # ª
+        b"\x00" # «
+        b"\x00" # ¬
+        b"\x00" # [not printable]
+        b"\x00" # ®
+        b"\x00" # ¯
+        b"\xb5"     # °
+        b"\x00" # ±
+        b"\x1f",      # ²
+        b"\x20",      # ³
+        b"\x2e"                         # ´
+        b"\x10",      # µ
+        b"\x00" # ¶
+        b"\x00" # ·
+        b"\x00" # ¸
+        b"\x00" # ¹
+        b"\x00" # º
+        b"\x00" # »
+        b"\x00" # ¼
+        b"\x00" # ½
+        b"\x00" # ¾
+        b"\x00" # ¿
+        b"\x00" # À
+        b"\x00" # Á
+        b"\x00" # Â
+        b"\x00" # Ã
+        b"\xb4"     # Ä
+        b"\x00" # Å
+        b"\x00" # Æ
+        b"\x00" # Ç
+        b"\x00" # È
+        b"\x00" # É
+        b"\x00" # Ê
+        b"\x00" # Ë
+        b"\x00" # Ì
+        b"\x00" # Í
+        b"\x00" # Î
+        b"\x00" # Ï
+        b"\x00" # Ð
+        b"\x00" # Ñ
+        b"\x00" # Ò
+        b"\x00" # Ó
+        b"\x00" # Ô
+        b"\x00" # Õ
+        b"\xb3"     # Ö
+        b"\x00" # ×
+        b"\x00" # Ø
+        b"\x00" # Ù
+        b"\x00" # Ú
+        b"\x00" # Û
+        b"\xaf"     # Ü
+        b"\x00" # Ý
+        b"\x00" # Þ
+        b"\x2d"                         # ß
+        b"\x00" # à
+        b"\x00" # á
+        b"\x00" # â
+        b"\x00" # ã
+        b"\x34"                         # ä
+        b"\x00" # å
+        b"\x00" # æ
+        b"\x00" # ç
+        b"\x00" # è
+        b"\x00" # é
+        b"\x00" # ê
+        b"\x00" # ë
+        b"\x00" # ì
+        b"\x00" # í
+        b"\x00" # î
+        b"\x00" # ï
+        b"\x00" # ð
+        b"\x00" # ñ
+        b"\x00" # ò
+        b"\x00" # ó
+        b"\x00" # ô
+        b"\x00" # õ
+        b"\x33"                         # ö
+        b"\x00" # ÷
+        b"\x00" # ø
+        b"\x00" # ù
+        b"\x00" # ú
+        b"\x00" # û
+        b"\x2f"                         # ü
+        b"\x00" # ý
+        b"\x00" # þ
+        b"\x00" # ÿ
+    )
+
+    NEED_ALTGR = "@[\\]{|}~²³µ"

--- a/libraries/keyboard_layout_win_fr.py
+++ b/libraries/keyboard_layout_win_fr.py
@@ -1,42 +1,25 @@
-# The MIT License (MIT)
+# SPDX-FileCopyrightText: 2017 Dan Halbert for Adafruit Industries
 #
-# Copyright (c) 2017 Dan Halbert
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
+# SPDX-License-Identifier: MIT
 
 """
-`adafruit_hid.keyboard_layout_fr.KeyboardLayoutFR`
+`adafruit_hid.keyboard_layout_us.KeyboardLayoutUS`
 =======================================================
 
-* Author(s): Dan Halbert, Neradoc
+* Author(s): Dan Halbert, maditnerd, AngainorDev
 """
 
-from adafruit_hid.keycode import Keycode
+# from adafruit_hid.keyboard_layout import KeyboardLayout
+from keyboard_layout import KeyboardLayout
 
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/Neradoc/Circuitpython_Keyboard_Layouts.git"
 
 
-class KeyboardLayoutFR:
-    """Map ASCII characters to appropriate keypresses on a FR Windows keyboard.
+class KeyboardLayoutFR(KeyboardLayout):
+    """Map ASCII characters to appropriate keypresses on a standard FR PC keyboard.
+    From https://github.com/adafruit/Adafruit_CircuitPython_HID/pull/54
     Non-ASCII characters and most control characters will raise an exception.
     """
 
@@ -53,210 +36,145 @@ class KeyboardLayoutFR:
     # if it's in a .mpy file, so it doesn't use up valuable RAM.
     #
     # \x00 entries have no keyboard key and so won't be sent.
-    SHIFT = b'\x02'
-    ALTGR = b'\x40'
     ASCII_TO_KEYCODE = (
-        b'\x00\x00'    # NUL
-        b'\x00\x00'    # SOH
-        b'\x00\x00'    # STX
-        b'\x00\x00'    # ETX
-        b'\x00\x00'    # EOT
-        b'\x00\x00'    # ENQ
-        b'\x00\x00'    # ACK
-        b'\x00\x00'    # BEL \a
-        b'\x00\x2a'    # BS BACKSPACE \b (called DELETE in the usb.org document)
-        b'\x00\x2b'    # TAB \t
-        b'\x00\x28'    # LF \n (called Return or ENTER in the usb.org document)
-        b'\x00\x00'    # VT \v
-        b'\x00\x00'    # FF \f
-        b'\x00\x00'    # CR \r
-        b'\x00\x00'    # SO
-        b'\x00\x00'    # SI
-        b'\x00\x00'    # DLE
-        b'\x00\x00'    # DC1
-        b'\x00\x00'    # DC2
-        b'\x00\x00'    # DC3
-        b'\x00\x00'    # DC4
-        b'\x00\x00'    # NAK
-        b'\x00\x00'    # SYN
-        b'\x00\x00'    # ETB
-        b'\x00\x00'    # CAN
-        b'\x00\x00'    # EM
-        b'\x00\x00'    # SUB
-        b'\x00\x29'    # ESC
-        b'\x00\x00'    # FS
-        b'\x00\x00'    # GS
-        b'\x00\x00'    # RS
-        b'\x00\x00'    # US
-        
-        b'\x00\x2c'       #  ' '
-        b'\x00\x38'       # !
-        b'\x00\x20'       # "
-        +SHIFT+b'\x20'    # #
-        b'\x00\x30'       # $
-        +SHIFT+b'\x34'    # %
-        b'\x00\x1E'       # &
-        b'\x00\x21'       # '
-        b'\x00\x22'       # (
-        b'\x00\x2d'       # )
-        b'\x00\x31'       # *
-        +SHIFT+b'\x2e'    # +
-        b'\x00\x10'       # ,
-        b'\x00\x23'       # -
-        +SHIFT+b'\x36'    # .
-        +SHIFT+b'\x37'    # /
-        +SHIFT+b'\x27'    # 0
-        +SHIFT+b'\x1e'    # 1
-        +SHIFT+b'\x1f'    # 2
-        +SHIFT+b'\x20'    # 3
-        +SHIFT+b'\x21'    # 4
-        +SHIFT+b'\x22'    # 5
-        +SHIFT+b'\x23'    # 6
-        +SHIFT+b'\x24'    # 7
-        +SHIFT+b'\x25'    # 8
-        +SHIFT+b'\x26'    # 9
-        b'\x00\x37'       # :
-        b'\x00\x36'       # ;
-        b'\x00\x64'       # <
-        b'\x00\x2e'       # =
-        +SHIFT+b'\x64'    # >
-        +SHIFT+b'\x10'    # ?
-        +ALTGR+b'\x27'    # @
-        +SHIFT+b'\x14'    # A
-        +SHIFT+b'\x05'    # B
-        +SHIFT+b'\x06'    # C
-        +SHIFT+b'\x07'    # D
-        +SHIFT+b'\x08'    # E
-        +SHIFT+b'\x09'    # F
-        +SHIFT+b'\x0a'    # G
-        +SHIFT+b'\x0b'    # H
-        +SHIFT+b'\x0c'    # I
-        +SHIFT+b'\x0d'    # J
-        +SHIFT+b'\x0e'    # K
-        +SHIFT+b'\x0f'    # L
-        +SHIFT+b'\x33'    # M
-        +SHIFT+b'\x11'    # N
-        +SHIFT+b'\x12'    # O
-        +SHIFT+b'\x13'    # P
-        +SHIFT+b'\x04'    # Q
-        +SHIFT+b'\x15'    # R
-        +SHIFT+b'\x16'    # S
-        +SHIFT+b'\x17'    # T
-        +SHIFT+b'\x18'    # U
-        +SHIFT+b'\x19'    # V
-        +SHIFT+b'\x1d'    # W
-        +SHIFT+b'\x1b'    # X
-        +SHIFT+b'\x1c'    # Y
-        +SHIFT+b'\x1a'    # Z
-        +ALTGR+b'\x22'    # [
-        b'\x00\x31'       # bslash
-        +ALTGR+b'\x2d'    # ]
-        b'\x00\x2F'       # ^
-        b'\x00\x25'       # _
-        +ALTGR+b'\x24'    # `
-        b'\x00\x14'       # a
-        b'\x00\x05'       # b
-        b'\x00\x06'       # c
-        b'\x00\x07'       # d
-        b'\x00\x08'       # e
-        b'\x00\x09'       # f
-        b'\x00\x0a'       # g
-        b'\x00\x0b'       # h
-        b'\x00\x0c'       # i
-        b'\x00\x0d'       # j
-        b'\x00\x0e'       # k
-        b'\x00\x0f'       # l
-        b'\x00\x33'       # m
-        b'\x00\x11'       # n
-        b'\x00\x12'       # o
-        b'\x00\x13'       # p
-        b'\x00\x04'       # q
-        b'\x00\x15'       # r
-        b'\x00\x16'       # s
-        b'\x00\x17'       # t
-        b'\x00\x18'       # u
-        b'\x00\x19'       # v
-        b'\x00\x1d'       # w
-        b'\x00\x1b'       # x
-        b'\x00\x1c'       # y
-        b'\x00\x1a'       # z
-        +ALTGR+b'\x21'    # {
-        +ALTGR+b'\x23'    # |
-        +ALTGR+b'\x2e'    # }
-        +ALTGR+b'\x19'    # ~ TODO
-        b'\x00\x4c'       # TODO DEL 
+        b"\x00"  # NUL
+        b"\x00"  # SOH
+        b"\x00"  # STX
+        b"\x00"  # ETX
+        b"\x00"  # EOT
+        b"\x00"  # ENQ
+        b"\x00"  # ACK
+        b"\x00"  # BEL \a
+        b"\x2a"  # BS BACKSPACE \b (called DELETE in the usb.org document)
+        b"\x2b"  # TAB \t
+        b"\x28"  # LF \n (called Return or ENTER in the usb.org document)
+        b"\x00"  # VT \v
+        b"\x00"  # FF \f
+        b"\x00"  # CR \r
+        b"\x00"  # SO
+        b"\x00"  # SI
+        b"\x00"  # DLE
+        b"\x00"  # DC1
+        b"\x00"  # DC2
+        b"\x00"  # DC3
+        b"\x00"  # DC4
+        b"\x00"  # NAK
+        b"\x00"  # SYN
+        b"\x00"  # ETB
+        b"\x00"  # CAN
+        b"\x00"  # EM
+        b"\x00"  # SUB
+        b"\x29"  # ESC
+        b"\x00"  # FS
+        b"\x00"  # GS
+        b"\x00"  # RS
+        b"\x00"  # US
+        b"\x2c"  # SPACE
+        b"\x38"  # ! x1e|SHIFT_FLAG (shift 1)
+        b"\x20"  # " x34|SHIFT_FLAG (shift ')
+        b"\xe0"  # # x20|SHIFT_FLAG (shift 3)
+        b"\x30"  # $ x21|SHIFT_FLAG (shift 4)
+        b"\xb4"  # % x22|SHIFT_FLAG (shift 5)
+        b"\x1e"  # & x24|SHIFT_FLAG (shift 7)
+        b"\x21"  # '
+        b"\x22"  # ( x26|SHIFT_FLAG (shift 9)
+        b"\x2d"  # ) x27|SHIFT_FLAG (shift 0)
+        b"\x31"  # * x25|SHIFT_FLAG (shift 8)
+        b"\xae"  # + x2e|SHIFT_FLAG (shift =)
+        b"\x10"  # ,
+        b"\x23"  # -
+        b"\xb6"  # .
+        b"\xb7"  # /
+        b"\xa7"  # 0 (SHIFT_FLAG)
+        b"\x9e"  # 1 (SHIFT_FLAG)
+        b"\x9f"  # 2 (SHIFT_FLAG)
+        b"\xa0"  # 3 (SHIFT_FLAG)
+        b"\xa1"  # 4 (SHIFT_FLAG)
+        b"\xa2"  # 5 (SHIFT_FLAG)
+        b"\xa3"  # 6 (SHIFT_FLAG)
+        b"\xa4"  # 7 (SHIFT_FLAG)
+        b"\xa5"  # 8 (SHIFT_FLAG)
+        b"\xa6"  # 9 (SHIFT_FLAG)
+        b"\x37"  # : x33|SHIFT_FLAG (shift ;)
+        b"\x36"  # ;
+        b"\x64"  # < x36|SHIFT_FLAG (shift ,)
+        b"\x2e"  # =
+        b"\x03"  # > x37|SHIFT_FLAG (shift .)
+        b"\x90"  # ? x38|SHIFT_FLAG (shift /)
+        b"\x27"  # @ x1f|SHIFT_FLAG (shift 2)
+        b"\x94"  # A x04|SHIFT_FLAG (shift a)
+        b"\x85"  # B x05|SHIFT_FLAG (etc.)
+        b"\x86"  # C x06|SHIFT_FLAG
+        b"\x87"  # D x07|SHIFT_FLAG
+        b"\x88"  # E x08|SHIFT_FLAG
+        b"\x89"  # F x09|SHIFT_FLAG
+        b"\x8a"  # G x0a|SHIFT_FLAG
+        b"\x8b"  # H x0b|SHIFT_FLAG
+        b"\x8c"  # I x0c|SHIFT_FLAG
+        b"\x8d"  # J x0d|SHIFT_FLAG
+        b"\x8e"  # K x0e|SHIFT_FLAG
+        b"\x8f"  # L x0f|SHIFT_FLAG
+        b"\xb3"  # M x10|SHIFT_FLAG
+        b"\x91"  # N x11|SHIFT_FLAG
+        b"\x92"  # O x12|SHIFT_FLAG
+        b"\x93"  # P x13|SHIFT_FLAG
+        b"\x84"  # Q x14|SHIFT_FLAG
+        b"\x95"  # R x15|SHIFT_FLAG
+        b"\x96"  # S x16|SHIFT_FLAG
+        b"\x97"  # T x17|SHIFT_FLAG
+        b"\x98"  # U x18|SHIFT_FLAG
+        b"\x99"  # V x19|SHIFT_FLAG
+        b"\x9d"  # W x1a|SHIFT_FLAG
+        b"\x9b"  # X x1b|SHIFT_FLAG
+        b"\x9c"  # Y x1c|SHIFT_FLAG
+        b"\x9a"  # Z x1d|SHIFT_FLAG
+        b"\x22"  # [
+        b"\x25"  # \ backslash
+        b"\x2d"  # ]
+        b"\x26"  # ^ x23|SHIFT_FLAG (shift 6)
+        b"\x25"  # _ x2d|SHIFT_FLAG (shift -)
+        b"\x24"  # `
+        b"\x14"  # a
+        b"\x05"  # b
+        b"\x06"  # c
+        b"\x07"  # d
+        b"\x08"  # e
+        b"\x09"  # f
+        b"\x0a"  # g
+        b"\x0b"  # h
+        b"\x0c"  # i
+        b"\x0d"  # j
+        b"\x0e"  # k
+        b"\x0f"  # l
+        b"\x33"  # m
+        b"\x11"  # n
+        b"\x12"  # o
+        b"\x13"  # p
+        b"\x04"  # q
+        b"\x15"  # r
+        b"\x16"  # s
+        b"\x17"  # t
+        b"\x18"  # u
+        b"\x19"  # v
+        b"\x1d"  # w
+        b"\x1b"  # x
+        b"\x1c"  # y
+        b"\x1a"  # z
+        b"\x21"  # {
+        b"\x23"  # |
+        b"\x2e"  # }
+        b"\x1f"  # ~ x35|SHIFT_FLAG (shift `)
+        b"\x4c"  # DEL DELETE (called Forward Delete in usb.org document)
     )
 
-    def __init__(self, keyboard):
-        """Specify the layout for the given keyboard.
-
-        :param keyboard: a Keyboard object. Write characters to this keyboard when requested.
-
-        Example::
-            kbd = Keyboard()
-            layout = KeyboardLayoutFR(kbd)
-        """
-
-        self.keyboard = keyboard
-
-    def write(self, string):
-        """Type the string by pressing and releasing keys on my keyboard.
-
-        :param string: A string of ASCII characters.
-        :raises ValueError: if any of the characters are not ASCII or have no keycode
-            (such as some control characters).
-
-        Example::
-            # Write abc followed by Enter to the keyboard
-            layout.write('abc\\n')
-        """
-        for char in string:
-            (modifier,keycode) = self._char_to_keycode(char)
-            # If this is a shifted char, clear the SHIFT flag and press the SHIFT key.
-            if modifier & self.SHIFT[0]:
-                self.keyboard.press(Keycode.SHIFT)
-            if modifier & self.ALTGR[0]:
-                self.keyboard.press(Keycode.GUI)
-            self.keyboard.press(keycode)
-            self.keyboard.release_all()
-
-    def keycodes(self, char):
-        """Return a tuple of keycodes needed to type the given character.
-
-        :param char: A single ASCII character in a string.
-        :type char: str of length one.
-        :returns: tuple of Keycode keycodes.
-        :raises ValueError: if ``char`` is not ASCII or there is no keycode for it.
-
-        Examples::
-            # Returns (Keycode.TAB,)
-            keycodes('\t')
-            # Returns (Keycode.A,)
-            keycode('a')
-            # Returns (Keycode.SHIFT, Keycode.A)
-            keycode('A')
-            # Raises ValueError because it's a accented e and is not ASCII
-            keycode('é')
-        """
-        out = []
-        (modifier,keycode) = self._char_to_keycode(char)
-        if modifier & self.SHIFT:
-            out += [Keycode.SHIFT]
-        if modifier & self.ALTGR:
-            out += [Keycode.GUI]
-        out += [keycode]
-        return out
-
-    def _char_to_keycode(self, char):
-        """Return the HID keycode for the given ASCII character, with the SHIFT_FLAG possibly set.
-        If the character requires pressing the Shift key, the SHIFT_FLAG bit is set.
-        You must clear this bit before passing the keycode in a USB report.
-        """
-        char_val = ord(char)*2
-        if char_val+1 >= len(self.ASCII_TO_KEYCODE):
-            raise ValueError("Unknown character.")
-        modifier = self.ASCII_TO_KEYCODE[char_val]
-        keycode = self.ASCII_TO_KEYCODE[char_val+1]
-        if keycode == 0:
-            raise ValueError("No keycode available for character.")
-        return (modifier,keycode)
+    NEED_ALTGR = "~{[|`\\^@]}€"
+    HIGHER_ASCII = {
+        "à": 0x27,  # à
+        "ç": 0x26,  # ç
+        "è": 0x24,  # è
+        "é": 0x1F,  # é
+        "ù": 0x34,  # ù
+        "€": 0x08,  # € - altgr will be added thanks to NEED_ALTGR
+        "°": 0xAD,  # °
+        #  TODO: add missing ÀÈÉÙ
+    }


### PR DESCRIPTION
Common KeyboardLayout class as a base for layouts.

- waiting for it to be added to adafruit_hid
- added the local requirement for all layout modules
- each layout needs no code in it
- NEED_ALTGR is used to add altgr for letters that require it
- HIGHER_ASCII lists codes for higher ascii characters (identified by string or ord)
- remove dependency from adafruit_hid.keycode
- RIGHT_ALT_CODE and SHIFT_CODE allow to override their keycodes

Update the readme to tell to install the `keyboard_layout.py` file.

US Dvorak not tested. Borrowed from:
https://github.com/adafruit/Adafruit_CircuitPython_HID/pull/60

German win_de_de keyboard not tested, from:
https://github.com/adafruit/Adafruit_CircuitPython_HID/pull/73
